### PR TITLE
Update telegrambots version to 5.0.1

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,6 +29,15 @@ public class Bot extends TelegramLongPollingBot {
 } 
 ```
 
+or for a webhook bot:
+
+```java
+@Component
+public class Bot extends TelegramWebhookBotService {
+...                                                  } 
+}
+```
+
 The bot will then be registered for you automatically on startup.
 
 ## Configuration

--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ or for a webhook bot:
 ```java
 @Component
 public class Bot extends TelegramWebhookBotService {
-...                                                  } 
+... 
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>11</java.version>
 		<glassfish.version>2.29.1</glassfish.version>
+		<telegrambots.version>5.0.1</telegrambots.version>
 	</properties>
 
 	<dependencies>
@@ -63,7 +64,7 @@
 		<dependency>
 		    <groupId>org.telegram</groupId>
 		    <artifactId>telegrambots</artifactId>
-		    <version>4.6</version>
+		    <version>${telegrambots.version}</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/github/xabgesagtx/bots/TelegramBotAutoConfiguration.java
+++ b/src/main/java/com/github/xabgesagtx/bots/TelegramBotAutoConfiguration.java
@@ -97,7 +97,9 @@ public class TelegramBotAutoConfiguration {
 
 	private DefaultWebhook getWebhookConfig(TelegramProperties properties) throws TelegramApiException {
 		DefaultWebhook webhook = new DefaultWebhook();
-		webhook.setKeyStore(properties.getKeyStore(), properties.getKeyStorePassword());
+		if (properties.hasKeyStoreWithPath()) {
+			webhook.setKeyStore(properties.getKeyStore(), properties.getKeyStorePassword());
+		}
 		webhook.setInternalUrl(properties.getInternalUrl());
 		return webhook;
 	}

--- a/src/main/java/com/github/xabgesagtx/bots/TelegramBotAutoConfiguration.java
+++ b/src/main/java/com/github/xabgesagtx/bots/TelegramBotAutoConfiguration.java
@@ -74,19 +74,21 @@ public class TelegramBotAutoConfiguration {
 	@ConditionalOnMissingBean
 	public TelegramBotsApi telegramBotsApi() throws TelegramApiException {
 		TelegramBotsApi result;
-		DefaultWebhook webhook = getWebhookConfig(properties);
 		if (properties.hasKeyStoreWithPath()) {
 			log.info("Initializing API with webhook support and configured keystore and path to certificate");
 			webhookBuilder.certificate(new InputFile(properties.getPathToCertificate()));
 			webhookBuilder.url(properties.getExternalUrl());
+			DefaultWebhook webhook = getWebhookConfig(properties);
 			result = new TelegramBotsApi(DefaultBotSession.class, webhook);
 		} else if (properties.hasKeyStore()) {
 			log.info("Initializing API with webhook support and configured keystore");
 			webhookBuilder.url(properties.getExternalUrl());
+			DefaultWebhook webhook = getWebhookConfig(properties);
 			result = new TelegramBotsApi(DefaultBotSession.class, webhook);
 		} else if (properties.hasUrls()) {
 			log.info("Initializing API with webhook support");
 			webhookBuilder.url(properties.getExternalUrl());
+			DefaultWebhook webhook = getWebhookConfig(properties);
 			result = new TelegramBotsApi(DefaultBotSession.class, webhook);
 		} else {
 			log.info("Initializing API without webhook support");

--- a/src/main/java/com/github/xabgesagtx/bots/TelegramBotAutoConfiguration.java
+++ b/src/main/java/com/github/xabgesagtx/bots/TelegramBotAutoConfiguration.java
@@ -55,7 +55,7 @@ public class TelegramBotAutoConfiguration {
 		webHookBots.forEach(bot -> {
 			try {
 				log.info("Registering web hook bot: {}", bot.getBotUsername());
-				SetWebhook webhook = bot.getInitializingWebhookRequest(webhookBuilder).build();
+				SetWebhook webhook = bot.customizeWebHook(webhookBuilder).build();
 				api.registerBot(bot, webhook);
 			} catch (TelegramApiException e) {
 				log.error("Failed to register bot {} due to error", bot.getBotUsername(), e);

--- a/src/main/java/com/github/xabgesagtx/bots/TelegramBotAutoConfiguration.java
+++ b/src/main/java/com/github/xabgesagtx/bots/TelegramBotAutoConfiguration.java
@@ -7,7 +7,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.telegram.telegrambots.ApiContextInitializer;
 import org.telegram.telegrambots.bots.TelegramWebhookBot;
 import org.telegram.telegrambots.meta.TelegramBotsApi;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
@@ -36,10 +35,6 @@ public class TelegramBotAutoConfiguration {
 	private final List<TelegramWebhookBot> webHookBots;
 	private final TelegramProperties properties;
 
-	static {
-		ApiContextInitializer.init();
-	}
-	
 	@PostConstruct
 	public void start() throws TelegramApiRequestException {
 		log.info("Starting auto config for telegram bots");
@@ -70,7 +65,7 @@ public class TelegramBotAutoConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	public TelegramBotsApi telegramBotsApi() throws TelegramApiRequestException {
+	public TelegramBotsApi telegramBotsApi() throws TelegramApiException {
 		TelegramBotsApi result;
 		if (properties.hasKeyStoreWithPath()) {
 			log.info("Initializing API with webhook support and configured keystore and path to certificate");
@@ -83,7 +78,7 @@ public class TelegramBotAutoConfiguration {
 			result = new TelegramBotsApi(properties.getExternalUrl(), properties.getInternalUrl());
 		} else {
 			log.info("Initializing API without webhook support");
-			result = new TelegramBotsApi();
+			result = new TelegramBotsApi(null);
 		}
 		return result;
 	}

--- a/src/main/java/com/github/xabgesagtx/bots/TelegramWebhookBotService.java
+++ b/src/main/java/com/github/xabgesagtx/bots/TelegramWebhookBotService.java
@@ -1,0 +1,20 @@
+package com.github.xabgesagtx.bots;
+
+import org.telegram.telegrambots.bots.TelegramWebhookBot;
+import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
+
+import javax.validation.constraints.NotNull;
+
+public abstract class TelegramWebhookBotService extends TelegramWebhookBot {
+	/**
+	 * Override this to configure the webhook for a single service here.
+	 * A set of configurations like "certificate" and "external Url" will be preconfigured
+	 *
+	 * @param webhook never null
+	 * @return the modified webhook
+	 */
+	public SetWebhook.SetWebhookBuilder getInitializingWebhookRequest(@NotNull SetWebhook.SetWebhookBuilder webhook) {
+		return webhook;
+	}
+
+}

--- a/src/main/java/com/github/xabgesagtx/bots/TelegramWebhookBotService.java
+++ b/src/main/java/com/github/xabgesagtx/bots/TelegramWebhookBotService.java
@@ -2,11 +2,21 @@ package com.github.xabgesagtx.bots;
 
 import org.telegram.telegrambots.bots.TelegramWebhookBot;
 import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
+import org.telegram.telegrambots.bots.DefaultBotOptions;
 
 /**
  * This class is a blueprint to generate a Webhook Bot.
  */
 public abstract class TelegramWebhookBotService extends TelegramWebhookBot {
+
+	public TelegramWebhookBotService() {
+	this(new DefaultBotOptions());
+  }
+
+	public TelegramWebhookBotService(DefaultBotOptions options) {
+	super(options);
+  }
+
 	/**
 	 * Override this to configure the webhook for a single service here.
 	 * A set of configurations like "certificate" and "external Url" will be preconfigured

--- a/src/main/java/com/github/xabgesagtx/bots/TelegramWebhookBotService.java
+++ b/src/main/java/com/github/xabgesagtx/bots/TelegramWebhookBotService.java
@@ -3,8 +3,9 @@ package com.github.xabgesagtx.bots;
 import org.telegram.telegrambots.bots.TelegramWebhookBot;
 import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
 
-import javax.validation.constraints.NotNull;
-
+/**
+ * This class is a blueprint to generate a Webhook Bot.
+ */
 public abstract class TelegramWebhookBotService extends TelegramWebhookBot {
 	/**
 	 * Override this to configure the webhook for a single service here.
@@ -13,7 +14,7 @@ public abstract class TelegramWebhookBotService extends TelegramWebhookBot {
 	 * @param webhook never null
 	 * @return the modified webhook
 	 */
-	public SetWebhook.SetWebhookBuilder getInitializingWebhookRequest(@NotNull SetWebhook.SetWebhookBuilder webhook) {
+	public SetWebhook.SetWebhookBuilder customizeWebHook(SetWebhook.SetWebhookBuilder webhook) {
 		return webhook;
 	}
 


### PR DESCRIPTION
Upgrade to 5.0.1, see https://github.com/xabgesagtx/telegram-spring-boot-starter/issues/6.
This also brings a breaking change, due to the new way of handling webhook bots.
For Webhook bots, you'll need to extend `TelegramWebhookBotService` .