### PR TITLE
upgrade spring-boot-starter-parent and telgrambots to fix #10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.6.RELEASE</version>
+        <version>2.5.7</version>
         <relativePath />
     </parent>
 
@@ -52,7 +52,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>11</java.version>
         <glassfish.version>2.32</glassfish.version>
-        <telegrambots.version>5.0.1</telegrambots.version>
+        <telegrambots.version>5.4.0.1</telegrambots.version>
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
     </properties>
 


### PR DESCRIPTION
There seems to be a breaking change for tests when spring-boot-starter-parent version >= 2.6.0....