### PR TITLE
Add support for local bot api

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,9 +9,9 @@ The starter is available at maven central. Just add the following dependency to 
 
 ```xml
 <dependency>
-	<groupId>com.github.xabgesagtx</groupId>
-	<artifactId>telegram-spring-boot-starter</artifactId>
-	<version>0.26</version>
+    <groupId>com.github.xabgesagtx</groupId>
+    <artifactId>telegram-spring-boot-starter</artifactId>
+    <version>0.26</version>
 </dependency>
 ```
 
@@ -34,7 +34,7 @@ or for a webhook bot:
 ```java
 @Component
 public class Bot extends TelegramWebhookBot {
-... 
+...
 }
 ```
 
@@ -42,7 +42,7 @@ if you want to overwrite a webhook for a specific bot:
 ```java
 @Component
 public class Bot extends CustomizableTelegramWebhookBot {
-... 
+...
 }
 ```
 
@@ -50,7 +50,7 @@ public class Bot extends CustomizableTelegramWebhookBot {
 The bot will then be registered for you automatically on startup.
 
 ## Configuration
- 
+
 The following properties can be configured (none are mandatory):
 
 | property                     | description                                    | available since |
@@ -60,7 +60,7 @@ The following properties can be configured (none are mandatory):
 | telegram.key-store           | keystore for the server                        | 0.15            |
 | telegram.key-store-password  | keystore password for the server               | 0.15            |
 | telegram.path-to-certificate | full path for .pem public certificate keys     | 0.15            |
-| telegram.local-bot-url       | base url for local bot api                     | 0.27             |
+| telegram.local-bot-url       | domain of local bot api (yourdomain.com/bot)   | 0.27            |
 | telegram.proxy.type          | type of proxy (NO_PROXY, HTTP, SOCKS4, SOCKS5) | 0.22            |
 | telegram.proxy.host          | host of the proxy                              | 0.22            |
 | telegram.proxy.port          | port of the proxy                              | 0.22            |
@@ -77,16 +77,37 @@ Also, `telegram.path-to-certificate` will only be used, if you configure the key
 
 ### Proxy support
 
-For proxy support you need to set all of the following properties: 
+For proxy support you need to set all of the following properties:
 * `telegram.proxy.type`
 * `telegram.proxy.host`
 * `telegram.proxy.port`
 
 To enable authentication for a proxy you need to set `telegram.proxy.user` and `telegram.proxy.password`.
 
+
+### Local Bot Api support
+For local bot api support you need to set following properties:
+* `telegram.local-bot-url`
+
+
 ### General
 
 In a regular spring boot setting these properties can be set in your `application.properties` or `application.yml`.
+
+To enable Proxy or Local Bot Api support you need to have a constructor with DefaultBotOptions as parameter :
+
+```java
+import org.telegram.telegrambots.bots.DefaultBotOptions;
+
+@Component
+public class Bot extends TelegramLongPollingBot {
+
+    public Bot(DefaultBotOptions options) {
+        super(options);
+    }
+...
+} 
+```
 
 For more information on how these configuration options work, please refer to the [TelegramBots Java API](https://github.com/rubenlagus/TelegramBots).
 

--- a/Readme.md
+++ b/Readme.md
@@ -53,18 +53,19 @@ The bot will then be registered for you automatically on startup.
  
 The following properties can be configured (none are mandatory):
 
-| property | description | available since |
-| -------- | ----------- | --------------- |
-| telegram.external-url | external base url for the webhook | 0.15 |
-| telegram.internal-url | internal base url for the webhook | 0.15 |
-| telegram.key-store | keystore for the server | 0.15 |
-| telegram.key-store-password | keystore password for the server | 0.15 |
-| telegram.path-to-certificate | full path for .pem public certificate keys | 0.15 |
-| telegram.proxy.type | type of proxy (NO_PROXY, HTTP, SOCKS4, SOCKS5) | 0.22 |
-| telegram.proxy.host | host of the proxy | 0.22 |
-| telegram.proxy.port | port of the proxy | 0.22 |
-| telegram.proxy.user | username for proxy authentication | 0.22 |
-| telegram.proxy.password | password for proxy authentication | 0.22 |
+| property                     | description                                    | available since |
+|------------------------------|------------------------------------------------|-----------------|
+| telegram.external-url        | external base url for the webhook              | 0.15            |
+| telegram.internal-url        | internal base url for the webhook              | 0.15            |
+| telegram.key-store           | keystore for the server                        | 0.15            |
+| telegram.key-store-password  | keystore password for the server               | 0.15            |
+| telegram.path-to-certificate | full path for .pem public certificate keys     | 0.15            |
+| telegram.local-bot-url       | base url for local bot api                     | 0.27             |
+| telegram.proxy.type          | type of proxy (NO_PROXY, HTTP, SOCKS4, SOCKS5) | 0.22            |
+| telegram.proxy.host          | host of the proxy                              | 0.22            |
+| telegram.proxy.port          | port of the proxy                              | 0.22            |
+| telegram.proxy.user          | username for proxy authentication              | 0.22            |
+| telegram.proxy.password      | password for proxy authentication              | 0.22            |
 
 ### Webhook support
 

--- a/src/main/java/com/github/xabgesagtx/bots/TelegramBotOptionsAutoConfiguration.java
+++ b/src/main/java/com/github/xabgesagtx/bots/TelegramBotOptionsAutoConfiguration.java
@@ -35,10 +35,7 @@ public class TelegramBotOptionsAutoConfiguration {
         botOptions.setProxyHost(properties.getHost());
         botOptions.setProxyPort(properties.getPort());
         botOptions.setProxyType(properties.getType());
-        if(plainProperties.hasLocalBotUrl())
-        {
-            botOptions.setBaseUrl(plainProperties.getLocalBotUrl());
-        }
+        addLocalBotUrlToOption(botOptions);
         return botOptions;
     }
 
@@ -46,11 +43,16 @@ public class TelegramBotOptionsAutoConfiguration {
     @ConditionalOnMissingBean(DefaultBotOptions.class)
     public DefaultBotOptions localBotApiOptions(){
         DefaultBotOptions botOptions = new DefaultBotOptions();
+        addLocalBotUrlToOption(botOptions);
+        return botOptions;
+    }
+
+    private void addLocalBotUrlToOption(DefaultBotOptions botOptions)
+    {
         if(plainProperties.hasLocalBotUrl())
         {
             botOptions.setBaseUrl(plainProperties.getLocalBotUrl());
         }
-        return botOptions;
     }
 
 

--- a/src/main/java/com/github/xabgesagtx/bots/TelegramBotOptionsAutoConfiguration.java
+++ b/src/main/java/com/github/xabgesagtx/bots/TelegramBotOptionsAutoConfiguration.java
@@ -13,10 +13,11 @@ import java.net.PasswordAuthentication;
 @Configuration
 @RequiredArgsConstructor
 @ConditionalOnProperty(value = {"host", "port", "type"}, prefix = "telegram.proxy")
-@Import(TelegramProxyProperties.class)
+@Import({TelegramProxyProperties.class, TelegramProperties.class})
 public class TelegramBotOptionsAutoConfiguration {
 
     private final TelegramProxyProperties properties;
+    private final TelegramProperties plainProperties;
 
     @Bean
     public DefaultBotOptions defaultBotOptions() {
@@ -32,6 +33,10 @@ public class TelegramBotOptionsAutoConfiguration {
         botOptions.setProxyHost(properties.getHost());
         botOptions.setProxyPort(properties.getPort());
         botOptions.setProxyType(properties.getType());
+        if(plainProperties.hasLocalBotUrl())
+        {
+            botOptions.setBaseUrl(plainProperties.getLocalBotUrl());
+        }
         return botOptions;
     }
 

--- a/src/main/java/com/github/xabgesagtx/bots/TelegramBotOptionsAutoConfiguration.java
+++ b/src/main/java/com/github/xabgesagtx/bots/TelegramBotOptionsAutoConfiguration.java
@@ -1,6 +1,8 @@
 package com.github.xabgesagtx.bots;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,13 +14,13 @@ import java.net.PasswordAuthentication;
 
 @Configuration
 @RequiredArgsConstructor
-@ConditionalOnProperty(value = {"host", "port", "type"}, prefix = "telegram.proxy")
-@Import({TelegramProxyProperties.class, TelegramProperties.class})
+@Import({TelegramProxyProperties.class,TelegramProperties.class})
 public class TelegramBotOptionsAutoConfiguration {
 
     private final TelegramProxyProperties properties;
     private final TelegramProperties plainProperties;
 
+    @ConditionalOnProperty(value = {"host", "port", "type"}, prefix = "telegram.proxy")
     @Bean
     public DefaultBotOptions defaultBotOptions() {
         if (properties.hasAuthData()) {
@@ -33,6 +35,17 @@ public class TelegramBotOptionsAutoConfiguration {
         botOptions.setProxyHost(properties.getHost());
         botOptions.setProxyPort(properties.getPort());
         botOptions.setProxyType(properties.getType());
+        if(plainProperties.hasLocalBotUrl())
+        {
+            botOptions.setBaseUrl(plainProperties.getLocalBotUrl());
+        }
+        return botOptions;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(DefaultBotOptions.class)
+    public DefaultBotOptions localBotApiOptions(){
+        DefaultBotOptions botOptions = new DefaultBotOptions();
         if(plainProperties.hasLocalBotUrl())
         {
             botOptions.setBaseUrl(plainProperties.getLocalBotUrl());

--- a/src/main/java/com/github/xabgesagtx/bots/TelegramProperties.java
+++ b/src/main/java/com/github/xabgesagtx/bots/TelegramProperties.java
@@ -14,6 +14,7 @@ class TelegramProperties {
     private String keyStore;
     private String keyStorePassword;
     private String pathToCertificate;
+    private String localBotUrl;
 
     boolean hasKeyStore() {
         return !StringUtils.isEmpty(keyStore) && !StringUtils.isEmpty(keyStorePassword);
@@ -30,4 +31,6 @@ class TelegramProperties {
     public boolean hasExternalUrl() {
         return StringUtils.hasText(externalUrl);
     }
+
+    public boolean hasLocalBotUrl() { return StringUtils.hasText(localBotUrl);}
 }

--- a/src/main/java/com/github/xabgesagtx/bots/TelegramProperties.java
+++ b/src/main/java/com/github/xabgesagtx/bots/TelegramProperties.java
@@ -32,5 +32,7 @@ class TelegramProperties {
         return StringUtils.hasText(externalUrl);
     }
 
-    public boolean hasLocalBotUrl() { return StringUtils.hasText(localBotUrl);}
+    public boolean hasLocalBotUrl(){
+        return StringUtils.hasText(localBotUrl);
+    }
 }


### PR DESCRIPTION
Hi,

From my personal project, support of local bot api is needed, so I added this function. 

Also I was aware that without calling super(DefaultBotOptions) in Bot bean , proxy will not be effective.

Thank.